### PR TITLE
:loud_sound: add log lines to the request

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -53,6 +53,10 @@ if [[ $(tail -1 ${FILE_DIR}/next-orders.cb) < $CURRENT_DATE ]];then
 	fi
 else
 	echo "$(date) -- Order already placed" >> ${FILE_DIR}/logfile.log
+	curl -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
+		-X POST \
+		"${WEBHOOK_URL}" \
+		--data "last-logs=$(tail ${FILE_DIR}/logfile.log)"
 	python ${SCRIPTPATH}/led_ok.py
 fi
 

--- a/init.sh
+++ b/init.sh
@@ -52,7 +52,9 @@ if [[ $(tail -1 ${FILE_DIR}/next-orders.cb) < $CURRENT_DATE ]];then
 		python ${SCRIPTPATH}/led_ko.py
 	fi
 else
-	echo "$(date) -- Order already placed" >> ${FILE_DIR}/logfile.log
+	echo "$(date) -- Order already placed \
+		on $(cat ${FILE_DIR}/sent-orders.cb) \
+		- not before $(cat ${FILE_DIR}/next-orders.cb)" >> ${FILE_DIR}/logfile.log
 	curl -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
 		-X POST \
 		"${WEBHOOK_URL}" \


### PR DESCRIPTION
This PR intends to add the last log lines on the `curl` request sent to Zapier. It will be filtered by it and don't send the email but we can easily check for problems or multiple button press with this feature.
Many thanx to @hgwood for the idea!