### PR TITLE
:bug: Add server sync for time update

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -7,6 +7,9 @@
 # - it then needs to shutdown the device
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# Update datetime on startup
+sudo ntpdate fr.pool.ntp.org
+
 # Files and directory check and/or creation
 [[ -d /etc/coffee-button ]] && echo "Directory exists" \
 	|| (mkdir -p /etc/coffee-button && echo "Directory created")


### PR DESCRIPTION
As described in #27, there was no time sync on Raspberry startup, leading to incoherent request and outdated logs.
This PR intends to fix that. It must be noted that `ntpdate` was added manually on the coffee-button with `sudo apt install ntpdate`.
Closes #27 